### PR TITLE
Ratings and Reviews - Helpful and Report Features

### DIFF
--- a/client/App.jsx
+++ b/client/App.jsx
@@ -11,7 +11,7 @@ class App extends React.Component {
     super(props);
 
     this.state = {
-      'product_id': '22122',
+      'product_id': '22124',
       info: null,
       selectedStyle: null,
       styleInfo: null,

--- a/client/ratings_reviews/RatingsReviews.jsx
+++ b/client/ratings_reviews/RatingsReviews.jsx
@@ -48,6 +48,7 @@ class RatingsReviews extends React.Component {
     });
 
     sessionStorage.setItem('helpfulReviews', JSON.stringify([]));
+    sessionStorage.setItem('reportedReviews', JSON.stringify([]));
   }
 
   handleOptionChanges(newOption) {

--- a/client/ratings_reviews/RatingsReviews.jsx
+++ b/client/ratings_reviews/RatingsReviews.jsx
@@ -46,6 +46,8 @@ class RatingsReviews extends React.Component {
     }).catch((error) => {
       console.log(error);
     });
+
+    sessionStorage.setItem('helpfulReviews', JSON.stringify([]));
   }
 
   handleOptionChanges(newOption) {

--- a/client/ratings_reviews/components/ReviewTile.jsx
+++ b/client/ratings_reviews/components/ReviewTile.jsx
@@ -17,7 +17,8 @@ class ReviewTile extends React.Component {
       showPhotos: false,
       showRecommend: false,
       showResponse: false,
-      reportStatus: false
+      reportStatus: false,
+      helpfulness: 0
     };
     this.toggleAdditionalBody = this.toggleAdditionalBody.bind(this);
     this.handleAddHelpful = this.handleAddHelpful.bind(this);
@@ -40,6 +41,18 @@ class ReviewTile extends React.Component {
     $.ajax({
       url: `reviews/${this.props.review.review_id}/helpful`,
       method: 'PUT'
+    }).then(() => {
+      var currentHelpfulReviews = sessionStorage.getItem('helpfulReviews');
+      if (currentHelpfulReviews === undefined) {
+        currentHelpfulReviews = [];
+      } else {
+        currentHelpfulReviews = JSON.parse(sessionStorage.getItem('helpfulReviews'));
+      }
+      currentHelpfulReviews.push(this.props.review.review_id);
+      sessionStorage.setItem('helpfulReviews', JSON.stringify(currentHelpfulReviews));
+      this.setState({
+        helpfulness: this.state.helpfulness + 1
+      });
     }).catch((error) => {
       console.log(error);
     });
@@ -49,16 +62,17 @@ class ReviewTile extends React.Component {
     $.ajax({
       url: `reviews/${this.props.review.review_id}/report`,
       method: 'PUT'
+    }).then(() => {
+      this.setState({
+        reportStatus: true
+      });
     }).catch((error) => {
       console.log(error);
-    });
-    this.setState({
-      reportStatus: true
     });
   }
 
   componentDidMount() {
-    var formattedReviewTileInfo = helpers.formatReviewTile(this.props.review.summary, this.props.review.body, this.props.review.photos);
+    var formattedReviewTileInfo = helpers.formatReviewTile(this.props.review.summary, this.props.review.body, this.props.review.photos, this.props.review.review_id);
     this.setState({
       summary: formattedReviewTileInfo[0],
       body: formattedReviewTileInfo[1],
@@ -69,7 +83,8 @@ class ReviewTile extends React.Component {
       showPhotos: formattedReviewTileInfo[4],
       showRecommend: this.props.review.recommend,
       showResponse: !(this.props.review.response === null || this.props.review.response.length === 0),
-      reportStatus: false
+      reportStatus: false,
+      helpfulness: Number.parseInt(this.props.review.helpfulness) + formattedReviewTileInfo[5]
     });
   }
 
@@ -92,7 +107,7 @@ class ReviewTile extends React.Component {
         <div>
           <span>Helpful?</span>
           <span class='review-clickable' onClick={this.handleAddHelpful}>Yes</span>
-          <span>({this.props.review.helpfulness}) | </span>
+          <span>({this.state.helpfulness}) | </span>
           {this.state.reportStatus === false ? <span class='review-clickable' onClick={this.handleReport}>Report</span> : <span>Reported!</span>}
         </div>
       </div>

--- a/client/ratings_reviews/components/ReviewTile.jsx
+++ b/client/ratings_reviews/components/ReviewTile.jsx
@@ -18,7 +18,8 @@ class ReviewTile extends React.Component {
       showRecommend: false,
       showResponse: false,
       reportStatus: false,
-      helpfulness: 0
+      helpfulness: 0,
+      showAddHelpfulButton: true
     };
     this.toggleAdditionalBody = this.toggleAdditionalBody.bind(this);
     this.handleAddHelpful = this.handleAddHelpful.bind(this);
@@ -46,7 +47,8 @@ class ReviewTile extends React.Component {
       currentHelpfulReviews.push(this.props.review.review_id);
       sessionStorage.setItem('helpfulReviews', JSON.stringify(currentHelpfulReviews));
       this.setState({
-        helpfulness: this.state.helpfulness + 1
+        helpfulness: this.state.helpfulness + 1,
+        showAddHelpfulButton: false
       });
     }).catch((error) => {
       console.log(error);
@@ -79,7 +81,8 @@ class ReviewTile extends React.Component {
       showRecommend: this.props.review.recommend,
       showResponse: !(this.props.review.response === null || this.props.review.response.length === 0),
       reportStatus: false,
-      helpfulness: this.props.review.helpfulness + formattedReviewTileInfo[5]
+      helpfulness: this.props.review.helpfulness + formattedReviewTileInfo[5],
+      showAddHelpfulButton: formattedReviewTileInfo[6]
     });
   }
 
@@ -101,7 +104,7 @@ class ReviewTile extends React.Component {
         <div class='seller-response' hidden={!this.state.showResponse}>Response: {this.props.review.response}</div>
         <div>
           <span>Helpful?</span>
-          <span class='review-clickable' onClick={this.handleAddHelpful}>Yes</span>
+          {this.state.showAddHelpfulButton ? <span class='review-clickable' onClick={this.handleAddHelpful}>Yes</span> : <span>Yes</span>}
           <span>({this.state.helpfulness}) | </span>
           {this.state.reportStatus === false ? <span class='review-clickable' onClick={this.handleReport}>Report</span> : <span>Reported!</span>}
         </div>

--- a/client/ratings_reviews/components/ReviewTile.jsx
+++ b/client/ratings_reviews/components/ReviewTile.jsx
@@ -20,6 +20,7 @@ class ReviewTile extends React.Component {
     };
     this.toggleAdditionalBody = this.toggleAdditionalBody.bind(this);
     this.handleAddHelpful = this.handleAddHelpful.bind(this);
+    this.handleReport = this.handleReport.bind(this);
   }
 
   toggleAdditionalBody(e) {
@@ -37,6 +38,15 @@ class ReviewTile extends React.Component {
   handleAddHelpful() {
     $.ajax({
       url: `reviews/${this.props.review.review_id}/helpful`,
+      method: 'PUT'
+    }).catch((error) => {
+      console.log(error);
+    });
+  }
+
+  handleReport() {
+    $.ajax({
+      url: `reviews/${this.props.review.review_id}/report`,
       method: 'PUT'
     }).catch((error) => {
       console.log(error);
@@ -78,7 +88,7 @@ class ReviewTile extends React.Component {
           <span>Helpful?</span>
           <span class='review-clickable' onClick={this.handleAddHelpful}>Yes</span>
           <span>({this.props.review.helpfulness}) | </span>
-          <span>Report</span>
+          <span class='review-clickable' onClick={this.handleReport}>Report</span>
         </div>
       </div>
     );

--- a/client/ratings_reviews/components/ReviewTile.jsx
+++ b/client/ratings_reviews/components/ReviewTile.jsx
@@ -16,7 +16,8 @@ class ReviewTile extends React.Component {
       showAdditionalBodyButton: false,
       showPhotos: false,
       showRecommend: false,
-      showResponse: false
+      showResponse: false,
+      reportStatus: false
     };
     this.toggleAdditionalBody = this.toggleAdditionalBody.bind(this);
     this.handleAddHelpful = this.handleAddHelpful.bind(this);
@@ -51,6 +52,9 @@ class ReviewTile extends React.Component {
     }).catch((error) => {
       console.log(error);
     });
+    this.setState({
+      reportStatus: true
+    });
   }
 
   componentDidMount() {
@@ -64,7 +68,8 @@ class ReviewTile extends React.Component {
       showAdditionalBodyButton: formattedReviewTileInfo[3],
       showPhotos: formattedReviewTileInfo[4],
       showRecommend: this.props.review.recommend,
-      showResponse: !(this.props.review.response === null || this.props.review.response.length === 0)
+      showResponse: !(this.props.review.response === null || this.props.review.response.length === 0),
+      reportStatus: false
     });
   }
 
@@ -88,7 +93,7 @@ class ReviewTile extends React.Component {
           <span>Helpful?</span>
           <span class='review-clickable' onClick={this.handleAddHelpful}>Yes</span>
           <span>({this.props.review.helpfulness}) | </span>
-          <span class='review-clickable' onClick={this.handleReport}>Report</span>
+          {this.state.reportStatus === false ? <span class='review-clickable' onClick={this.handleReport}>Report</span> : <span>Reported!</span>}
         </div>
       </div>
     );

--- a/client/ratings_reviews/components/ReviewTile.jsx
+++ b/client/ratings_reviews/components/ReviewTile.jsx
@@ -19,7 +19,8 @@ class ReviewTile extends React.Component {
       showResponse: false,
       reportStatus: false,
       helpfulness: 0,
-      showAddHelpfulButton: true
+      showAddHelpfulButton: true,
+      reportStatus: false
     };
     this.toggleAdditionalBody = this.toggleAdditionalBody.bind(this);
     this.handleAddHelpful = this.handleAddHelpful.bind(this);
@@ -60,6 +61,9 @@ class ReviewTile extends React.Component {
       url: `reviews/${this.props.review.review_id}/report`,
       method: 'PUT'
     }).then(() => {
+      var currentReportedReviews = JSON.parse(sessionStorage.getItem('reportedReviews'));
+      currentReportedReviews.push(this.props.review.review_id);
+      sessionStorage.setItem('reportedReviews', JSON.stringify(currentReportedReviews));
       this.setState({
         reportStatus: true
       });
@@ -82,7 +86,8 @@ class ReviewTile extends React.Component {
       showResponse: !(this.props.review.response === null || this.props.review.response.length === 0),
       reportStatus: false,
       helpfulness: this.props.review.helpfulness + formattedReviewTileInfo[5],
-      showAddHelpfulButton: formattedReviewTileInfo[6]
+      showAddHelpfulButton: formattedReviewTileInfo[6],
+      reportStatus: formattedReviewTileInfo[7]
     });
   }
 
@@ -106,7 +111,7 @@ class ReviewTile extends React.Component {
           <span>Helpful?</span>
           {this.state.showAddHelpfulButton ? <span class='review-clickable' onClick={this.handleAddHelpful}>Yes</span> : <span>Yes</span>}
           <span>({this.state.helpfulness}) | </span>
-          {this.state.reportStatus === false ? <span class='review-clickable' onClick={this.handleReport}>Report</span> : <span>Reported!</span>}
+          {!this.state.reportStatus ? <span class='review-clickable' onClick={this.handleReport}>Report</span> : <span>Reported!</span>}
         </div>
       </div>
     );

--- a/client/ratings_reviews/components/ReviewTile.jsx
+++ b/client/ratings_reviews/components/ReviewTile.jsx
@@ -42,12 +42,7 @@ class ReviewTile extends React.Component {
       url: `reviews/${this.props.review.review_id}/helpful`,
       method: 'PUT'
     }).then(() => {
-      var currentHelpfulReviews = sessionStorage.getItem('helpfulReviews');
-      if (currentHelpfulReviews === undefined) {
-        currentHelpfulReviews = [];
-      } else {
-        currentHelpfulReviews = JSON.parse(sessionStorage.getItem('helpfulReviews'));
-      }
+      var currentHelpfulReviews = JSON.parse(sessionStorage.getItem('helpfulReviews'));
       currentHelpfulReviews.push(this.props.review.review_id);
       sessionStorage.setItem('helpfulReviews', JSON.stringify(currentHelpfulReviews));
       this.setState({
@@ -84,7 +79,7 @@ class ReviewTile extends React.Component {
       showRecommend: this.props.review.recommend,
       showResponse: !(this.props.review.response === null || this.props.review.response.length === 0),
       reportStatus: false,
-      helpfulness: Number.parseInt(this.props.review.helpfulness) + formattedReviewTileInfo[5]
+      helpfulness: this.props.review.helpfulness + formattedReviewTileInfo[5]
     });
   }
 

--- a/client/ratings_reviews/components/ReviewTile.jsx
+++ b/client/ratings_reviews/components/ReviewTile.jsx
@@ -19,6 +19,7 @@ class ReviewTile extends React.Component {
       showResponse: false
     };
     this.toggleAdditionalBody = this.toggleAdditionalBody.bind(this);
+    this.handleAddHelpful = this.handleAddHelpful(this);
   }
 
   toggleAdditionalBody(e) {
@@ -31,6 +32,16 @@ class ReviewTile extends React.Component {
     } else {
       $(e.target).text('Show More');
     }
+  }
+
+  handleAddHelpful() {
+    console.log('review_id: ', this.props.review.review_id);
+    $.ajax({
+      url: `reviews/${this.props.review.review_id}/helpful`,
+      method: 'PUT'
+    }).catch((error) => {
+      console.log(error);
+    });
   }
 
   componentDidMount() {
@@ -64,7 +75,7 @@ class ReviewTile extends React.Component {
         </div>
         <div class='user-recommend' hidden={!this.state.showRecommend}>I recommend this product!</div>
         <div class='seller-response' hidden={!this.state.showResponse}>Response: {this.props.review.response}</div>
-        <div><span>Helpful? Yes ({this.props.review.helpfulness}) | Report</span></div>
+        <div><span>Helpful? <span class='review-clickable' onClick={this.handleAddHelpful}>Yes</span> ({this.props.review.helpfulness}) | Report</span></div>
       </div>
     );
   }

--- a/client/ratings_reviews/components/ReviewTile.jsx
+++ b/client/ratings_reviews/components/ReviewTile.jsx
@@ -19,7 +19,7 @@ class ReviewTile extends React.Component {
       showResponse: false
     };
     this.toggleAdditionalBody = this.toggleAdditionalBody.bind(this);
-    this.handleAddHelpful = this.handleAddHelpful(this);
+    this.handleAddHelpful = this.handleAddHelpful.bind(this);
   }
 
   toggleAdditionalBody(e) {
@@ -35,7 +35,6 @@ class ReviewTile extends React.Component {
   }
 
   handleAddHelpful() {
-    console.log('review_id: ', this.props.review.review_id);
     $.ajax({
       url: `reviews/${this.props.review.review_id}/helpful`,
       method: 'PUT'
@@ -75,7 +74,12 @@ class ReviewTile extends React.Component {
         </div>
         <div class='user-recommend' hidden={!this.state.showRecommend}>I recommend this product!</div>
         <div class='seller-response' hidden={!this.state.showResponse}>Response: {this.props.review.response}</div>
-        <div><span>Helpful? <span class='review-clickable' onClick={this.handleAddHelpful}>Yes</span> ({this.props.review.helpfulness}) | Report</span></div>
+        <div>
+          <span>Helpful?</span>
+          <span class='review-clickable' onClick={this.handleAddHelpful}>Yes</span>
+          <span>({this.props.review.helpfulness}) | </span>
+          <span>Report</span>
+        </div>
       </div>
     );
   }

--- a/client/ratings_reviews/components/ReviewsList.jsx
+++ b/client/ratings_reviews/components/ReviewsList.jsx
@@ -82,8 +82,10 @@ class ReviewsList extends React.Component {
       return (
         <div key={this.props.reviews[0].review_id} class='reviews-list'>
           <div class='reviews-list-tiles'>{this.state.currentReviews.map(review => <ReviewTile review={review}/>)}</div>
-          <button class='review-show-button' onClick={this.showMoreReviews} hidden={!this.state.showMoreReviewsButton}>More Reviews</button>
-          <button class='review-show-button' onClick={this.showLessReviews} hidden={!this.state.showLessReviewsButton}>Less Reviews</button>
+          <div>
+            <button class='review-show-button' onClick={this.showMoreReviews} hidden={!this.state.showMoreReviewsButton}>More Reviews</button>
+            <button class='review-show-button' onClick={this.showLessReviews} hidden={!this.state.showLessReviewsButton}>Less Reviews</button>
+          </div>
         </div>
       );
     } else {

--- a/client/ratings_reviews/helpers.js
+++ b/client/ratings_reviews/helpers.js
@@ -138,6 +138,7 @@ const formatReviewTile = (summary, body, photos, reviewId) => {
   var showAdditionalBodyButton = false;
   var showPhotos = false;
   var helpful = 0;
+  var showAddHelpfulButton = true;
   if (summary.length > 60) {
     summary = summary.slice(0, 61) + '...';
   }
@@ -152,8 +153,9 @@ const formatReviewTile = (summary, body, photos, reviewId) => {
   var currentHelpfulReviews = JSON.parse(sessionStorage.getItem('helpfulReviews'));
   if (currentHelpfulReviews.indexOf(reviewId) !== -1) {
     helpful = 1;
+    showAddHelpfulButton = false;
   }
-  return [summary, body, additionalBody, showAdditionalBodyButton, showPhotos, helpful];
+  return [summary, body, additionalBody, showAdditionalBodyButton, showPhotos, helpful, showAddHelpfulButton];
 };
 
 module.exports = {

--- a/client/ratings_reviews/helpers.js
+++ b/client/ratings_reviews/helpers.js
@@ -149,11 +149,9 @@ const formatReviewTile = (summary, body, photos, reviewId) => {
   if (photos.length !== 0) {
     showPhotos = true;
   }
-  var currentHelpfulReviews = sessionStorage.getItem('helpfulReviews');
-  if (currentHelpfulReviews !== undefined) {
-    if (JSON.parse(currentHelpfulReviews).indexOf(Number.parseInt(reviewId)) !== -1) {
-      helpful = 1;
-    }
+  var currentHelpfulReviews = JSON.parse(sessionStorage.getItem('helpfulReviews'));
+  if (currentHelpfulReviews.indexOf(reviewId) !== -1) {
+    helpful = 1;
   }
   return [summary, body, additionalBody, showAdditionalBodyButton, showPhotos, helpful];
 };

--- a/client/ratings_reviews/helpers.js
+++ b/client/ratings_reviews/helpers.js
@@ -133,10 +133,11 @@ const applyStarFilters = (reviews, starFilters) => {
   return output;
 };
 
-const formatReviewTile = (summary, body, photos) => {
+const formatReviewTile = (summary, body, photos, reviewId) => {
   var additionalBody = '';
   var showAdditionalBodyButton = false;
   var showPhotos = false;
+  var helpful = 0;
   if (summary.length > 60) {
     summary = summary.slice(0, 61) + '...';
   }
@@ -148,7 +149,13 @@ const formatReviewTile = (summary, body, photos) => {
   if (photos.length !== 0) {
     showPhotos = true;
   }
-  return [summary, body, additionalBody, showAdditionalBodyButton, showPhotos];
+  var currentHelpfulReviews = sessionStorage.getItem('helpfulReviews');
+  if (currentHelpfulReviews !== undefined) {
+    if (JSON.parse(currentHelpfulReviews).indexOf(Number.parseInt(reviewId)) !== -1) {
+      helpful = 1;
+    }
+  }
+  return [summary, body, additionalBody, showAdditionalBodyButton, showPhotos, helpful];
 };
 
 module.exports = {

--- a/client/ratings_reviews/helpers.js
+++ b/client/ratings_reviews/helpers.js
@@ -139,6 +139,7 @@ const formatReviewTile = (summary, body, photos, reviewId) => {
   var showPhotos = false;
   var helpful = 0;
   var showAddHelpfulButton = true;
+  var reportStatus = false;
   if (summary.length > 60) {
     summary = summary.slice(0, 61) + '...';
   }
@@ -155,7 +156,11 @@ const formatReviewTile = (summary, body, photos, reviewId) => {
     helpful = 1;
     showAddHelpfulButton = false;
   }
-  return [summary, body, additionalBody, showAdditionalBodyButton, showPhotos, helpful, showAddHelpfulButton];
+  var currentReportedReviews = JSON.parse(sessionStorage.getItem('reportedReviews'));
+  if (currentReportedReviews.indexOf(reviewId) !== -1) {
+    reportStatus = true;
+  }
+  return [summary, body, additionalBody, showAdditionalBodyButton, showPhotos, helpful, showAddHelpfulButton, reportStatus];
 };
 
 module.exports = {


### PR DESCRIPTION
- Reviews can now be reported or flagged as helpful
- Report status and Helpful status are saved in session storage
- Report status and Helpful status persist even after review tiles are being re-rendered (by filtering)