### PR TITLE
Resolved bug when current product ID is returned in related product IDs

### DIFF
--- a/client/related_items/helpers.js
+++ b/client/related_items/helpers.js
@@ -2,7 +2,11 @@ const getRelatedItems = (productId) => {
   return new Promise (resolve => {
     fetch(`http://localhost:8080/products/${productId}/related`)
       .then(response => response.json())
-      .then(data => resolve(data));
+      .then(data => {
+        let mainProductId = parseInt(productId);
+        let noDuplicates = data.filter(id => id !== mainProductId);
+        resolve(noDuplicates);
+      });
   });
 };
 


### PR DESCRIPTION
- Updated helper function to remove a related product ID if it is the same as the current product ID

@alizehrehman @tchitrakorn @matthewwrobel another late one so tagging everyone!